### PR TITLE
fix: store empty phone_number as NULL to avoid unique constraint conflicts

### DIFF
--- a/ace-the-entrance/accounts/models.py
+++ b/ace-the-entrance/accounts/models.py
@@ -25,7 +25,12 @@ class User(AbstractUser):
 
     def __str__(self):
         return self.email
-
+    
+    def save(self, *args, **kwargs):
+        # Ensure empty phone numbers are stored as NULL
+        if not self.phone_number:
+            self.phone_number = None
+        super().save(*args, **kwargs)
 
 class UserOnboarding(models.Model):
     PURPOSE_CHOICES = [


### PR DESCRIPTION
## Summary
Fixes an issue where the optional `phone_number` field caused unique constraint conflicts when left empty.

Closes #18

## What Changed
- Ensured empty phone_number values are stored as NULL instead of empty strings
- Added normalization logic in the model's save method

## Why
Empty strings were being treated as duplicate values due to the unique constraint. Using NULL allows multiple users to leave the field blank.

## Verification
- Tested user creation without phone numbers
- Verified in PostgreSQL using `IS NULL` queries
- Confirmed multiple NULL values do not violate unique constraints